### PR TITLE
Expand regular expression formatting for special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ There are special characters for regular expressions which may disrupt how Cinem
 The special characters we have allow include: ``[``, ``]``, ``(``, ``)``, ``\``, ``^``, ``$``, ``.``, ``?``, ``*``, and ``+``.
 If you are having problems with hiding or alter particular axes, then it may be due to the parameter's name.
 
+If you wish to use a special character in the ``databases.json`` JSON file, then you must include a ``\\`` before the special character.
+An example is shown in ``databases.json`` already under ``Exmaple (Test Filter and Logscale)``.
+You see there that the ``logscale`` is set to ``"Temp\\[C\\]"`` so that the ``[`` and ``]`` special characters are properly parsed in the JSON file.
+
 ## Hide column or change to logarithmic scale in web browser
 
 Once you have loaded the viewer in a browser, then you can change which columns are displayed, the axes scales, and other visualization options in the viewer.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ The following are a description of the example entries
   * ``Example (Test Expression)``: An example that shows how to initially only display columns that contain ``CHISQ`` or ``PF6``.
   * ``Example (Display All)``: Simple example that shows the entire dataset.
 
+## Parameter names with special characters
+
+Cinema:Debye-Scherrer uses regular expressions to sort parameters.
+There are special characters for regular expressions which may disrupt how Cinema:Debye-Scherrer operates.
+The special characters we have allow include: ``[``, ``]``, ``(``, ``)``, ``\``, ``^``, ``$``, ``.``, ``?``, ``*``, and ``+``.
+If you are having problems with hiding or alter particular axes, then it may be due to the parameter's name.
+
 ## Hide column or change to logarithmic scale in web browser
 
 Once you have loaded the viewer in a browser, then you can change which columns are displayed, the axes scales, and other visualization options in the viewer.

--- a/README.md
+++ b/README.md
@@ -109,9 +109,8 @@ The following are a description of the example entries
 ## Parameter names with special characters
 
 Cinema:Debye-Scherrer uses regular expressions to sort parameters.
-There are special characters for regular expressions which may disrupt how Cinema:Debye-Scherrer operates.
-The special characters we have allow include: ``[``, ``]``, ``(``, ``)``, ``\``, ``^``, ``$``, ``.``, ``?``, ``*``, and ``+``.
-If you are having problems with hiding or alter particular axes, then it may be due to the parameter's name.
+We have taken precautions to safeguard against special characters for regular expressions which may disrupt how Cinema:Debye-Scherrer operates.
+The special characters we allow in parameter names include: ``[``, ``]``, ``(``, ``)``, ``\``, ``^``, ``$``, ``.``, ``?``, ``*``, and ``+``.
 
 If you wish to use a special character in the ``databases.json`` JSON file, then you must include a ``\\`` before the special character.
 An example is shown in ``databases.json`` already under ``Exmaple (Test Filter and Logscale)``.

--- a/databases.json
+++ b/databases.json
@@ -10,7 +10,7 @@
                 "name" : "Example (Test Filter and Logscale)",
                 "directory" : "data/example.cdb",
                 "filter" : "BaBrCl|File|FILE",
-                "logscale" : "Temp",
+                "logscale" : "Temp \\[C\\]",
                 "smoothLines" : true,
                 "lineOpacity" : 1.0
         },

--- a/js/Axial.js
+++ b/js/Axial.js
@@ -247,11 +247,11 @@
          * This includes: (, ), [, ], \, ^, $, ., ?, *, and +.
          */
         CINEMA_COMPONENTS.Axial.prototype.formatRegExp = function(param) {
-            return param.replace(/\(/g, "\\\(")
+            return param.replace(/\\/g, "\\\\")
+                        .replace(/\(/g, "\\\(")
                         .replace(/\)/g, "\\\)")
                         .replace(/\[/g, "\\\[")
                         .replace(/\]/g, "\\\]")
-                        .replace(/\\/g, "\\\\")
                         .replace(/\^/g, "\\\^")
                         .replace(/\$/g, "\\\$")
                         .replace(/\./g, "\\\.")

--- a/js/Axial.js
+++ b/js/Axial.js
@@ -244,14 +244,20 @@
 
         /**
          * For special characters in regular expression adds blackslashes.
-         * This includes: (, ), [, and ].
-         * This does not include: \, ^, $, ., ?, *, and +.
+         * This includes: (, ), [, ], \, ^, $, ., ?, *, and +.
          */
         CINEMA_COMPONENTS.Axial.prototype.formatRegExp = function(param) {
             return param.replace(/\(/g, "\\\(")
                         .replace(/\)/g, "\\\)")
                         .replace(/\[/g, "\\\[")
-                        .replace(/\]/g, "\\\]");
+                        .replace(/\]/g, "\\\]")
+                        .replace(/\\/g, "\\\\")
+                        .replace(/\^/g, "\\\^")
+                        .replace(/\$/g, "\\\$")
+                        .replace(/\./g, "\\\.")
+                        .replace(/\?/g, "\\\?")
+                        .replace(/\*/g, "\\\*")
+                        .replace(/\+/g, "\\\+");
         }
 
 })();

--- a/js/Axial.js
+++ b/js/Axial.js
@@ -218,10 +218,11 @@
             d3.selectAll('.customControlRow').nodes().forEach(function(d) {
 
                 // get name
-                var param = d.textContent;
+                var param = self.formatRegExp(d.textContent);
 
                 // determine if hide checked
                 if (d.children[1].children[0].checked) {
+
                     filterDimensions.push(param);
                 }
                 // determine if logscale checked
@@ -239,6 +240,18 @@
             currentDbInfo.logscale = logscaleDimensions.length > 0 ? logscaleDimensions.join("|") : "^$";
             load();
 
+        }
+
+        /**
+         * For special characters in regular expression adds blackslashes.
+         * This includes: (, ), [, and ].
+         * This does not include: \, ^, $, ., ?, *, and +.
+         */
+        CINEMA_COMPONENTS.Axial.prototype.formatRegExp = function(param) {
+            return param.replace(/\(/g, "\\\(")
+                        .replace(/\)/g, "\\\)")
+                        .replace(/\[/g, "\\\[")
+                        .replace(/\]/g, "\\\]");
         }
 
 })();


### PR DESCRIPTION
This adds a function that replaces ``[``, ``]``, ``(``, and ``)`` with backslashes before them in parameter names. This needs to be done for special characters in regular expressions.

At the moment this does not include:  ``\``, ``^``, ``$``, ``.``, ``?``, ``*``, and ``+``.

Adds a bit to the README documentation about this topic.